### PR TITLE
Support RelaxNG Compact Syntax media type in <p:validate-with-relax-ng>

### DIFF
--- a/langspec/xproc11-steps/steps.xml
+++ b/langspec/xproc11-steps/steps.xml
@@ -3118,7 +3118,9 @@ validation to the <port>source</port> document.</para>
 
 <para>If the <port>schema</port> document has an XML media type, then
 it <rfc2119>must</rfc2119> be interpreted as a RELAX NG Grammar. If
-the media type has a “<literal>text</literal>” type, then it
+the <port>schema</port> document has the media type
+“<literal>application/relax-ng-compact-syntax</literal>” or the media
+type has a “<literal>text</literal>” type, then it
 <rfc2119>must</rfc2119> be interpreted as a <biblioref
 linkend="relaxng-compact-syntax"/> document for validation.</para>
 


### PR DESCRIPTION
Fix #90